### PR TITLE
Feature(dashboard): implement navigation section for dashboard page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@icons-pack/react-simple-icons": "^9.3.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.10.2",
+        "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-label": "^2.0.2",
@@ -587,6 +588,32 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.0.4.tgz",
+      "integrity": "sha512-kVK2K7ZD3wwj3qhle0ElXhOjbezIgyl2hVvgwfIdexL3rN6zJmy5AqqIf+D31lxVppdzV8CjAfZ6PklkmInZLw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-radio-group": "^1.1.3",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-tabs": "^1.0.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.344.0",
@@ -1105,6 +1106,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tabs": "^1.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.344.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@icons-pack/react-simple-icons": "^9.3.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.10.2",
+    "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,25 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-export default function DashboardPage() {
+const VIEW_MODES = {
+    KANBAN: "kanban",
+    LIST: "list"
+} as const
+
+type ViewMode = keyof typeof VIEW_MODES
+
+/**
+ * Expected query parameters for `DashboardPage`
+ */
+type SearchParams = {
+    view: ViewMode
+}
+
+export default function DashboardPage({ searchParams }: { searchParams: SearchParams } ) {
+    const { view: defaultViewMode } = searchParams
+
     // TODO: workspaces should be populated with users workspaces provided by backend
     const WORKSPACES = [
         {
@@ -20,8 +37,8 @@ export default function DashboardPage() {
     ]
 
     return (
-        <main className="min-h-screen p-12">
-            <nav className="flex flex-col gap-4">
+        <main className="min-h-screen p-12 flex flex-col gap-8">
+            <nav className="flex-grow-0">
                 <div className="flex gap-6">
                     <Select>
                         <SelectTrigger className="w-1/5">
@@ -45,13 +62,30 @@ export default function DashboardPage() {
                         <AvatarFallback>GO</AvatarFallback>
                     </Avatar>
                 </div>
-
-                <div>
-
-                </div>
             </nav>
 
-            <section className="h-full">
+            <section className="flex flex-col flex-grow h-full">
+                {/* TODO: `defaultValue` should come from query parameters in order to provide the state of the current view */}
+                <Tabs defaultValue={defaultViewMode} className="flex flex-col flex-grow">
+                    <header className="flex flex-col gap-1 items-center flex-grow-0">
+                        <TabsList className="px-3 py-6">
+                            <TabsTrigger className="w-[100px]" value={VIEW_MODES.KANBAN}>Kanban</TabsTrigger>
+                            <TabsTrigger className="w-[100px]" value={VIEW_MODES.LIST}>List</TabsTrigger>
+                        </TabsList>
+                    </header>
+
+                    <div className="flex justify-center items-center flex-grow">
+                        <TabsContent value={VIEW_MODES.KANBAN}>
+                            {/* TODO: should render Kanban visualization component */}
+                            <p>This is the kanban</p>
+                        </TabsContent>
+
+                        <TabsContent value={VIEW_MODES.LIST}>
+                            {/* TODO: should render List visualization component */}
+                            <p>This is the list</p>
+                        </TabsContent>
+                    </div>
+                </Tabs>
             </section>
         </main>
     )

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -20,8 +20,9 @@ type SearchParams = {
     view: ViewMode
 }
 
-export default function DashboardPage({ searchParams }: { searchParams: SearchParams } ) {
-    const { view: defaultViewMode } = searchParams
+export default function DashboardPage({ searchParams }: { searchParams: Partial<SearchParams> } ) {
+    const { view } = searchParams
+    const defaultViewMode = view ?? VIEW_MODES.KANBAN
 
     // TODO: workspaces should be populated with users workspaces provided by backend
     const WORKSPACES = [

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,9 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
+/**
+ * Available view modes for the tasks display in dashboard.
+ */
 const VIEW_MODES = {
     KANBAN: "kanban",
     LIST: "list"
@@ -11,7 +14,7 @@ const VIEW_MODES = {
 type ViewMode = keyof typeof VIEW_MODES
 
 /**
- * Expected query parameters for `DashboardPage`
+ * Expected query parameters for `DashboardPage`.
  */
 type SearchParams = {
     view: ViewMode
@@ -37,13 +40,13 @@ export default function DashboardPage({ searchParams }: { searchParams: SearchPa
     ]
 
     return (
-        <main className="min-h-screen p-12 flex flex-col gap-8">
+        <main className="min-h-screen p-4 flex flex-col gap-4 md:gap-6 md:p-10">
             <nav className="flex-grow-0">
-                <div className="flex gap-6">
+                <div className="flex flex-col gap-2 md:flex-row md:gap-6">
                     <Select>
-                        <SelectTrigger className="w-1/5">
+                        <SelectTrigger className="w-full md:w-1/5">
                             <SelectValue placeholder="Workspace" />
-                        </SelectTrigger>   
+                        </SelectTrigger>
 
                         <SelectContent>
                             {WORKSPACES.map(({ value, label }) => (
@@ -52,12 +55,12 @@ export default function DashboardPage({ searchParams }: { searchParams: SearchPa
                         </SelectContent>
                     </Select> 
 
+                    {/* TODO: add event listener to focus search input on (Ctrl + K) keypress */}
                     <Input placeholder="Search for a task (Ctrl + K)" />
 
-                    <Avatar className="rounded-md">
+                    <Avatar className="rounded-md hidden md:block">
                         {/* TODO: `src` property should reference to user avatar database column */}
                         <AvatarImage src="https://www.clipartmax.com/png/middle/105-1055054_view-golang-think-logo-golang.png"/>
-
                         {/* TODO: fallback should be fullfilled with the first letters of the user name and lastname */}
                         <AvatarFallback>GO</AvatarFallback>
                     </Avatar>
@@ -68,9 +71,9 @@ export default function DashboardPage({ searchParams }: { searchParams: SearchPa
                 {/* TODO: `defaultValue` should come from query parameters in order to provide the state of the current view */}
                 <Tabs defaultValue={defaultViewMode} className="flex flex-col flex-grow">
                     <header className="flex flex-col gap-1 items-center flex-grow-0">
-                        <TabsList className="px-3 py-6">
-                            <TabsTrigger className="w-[100px]" value={VIEW_MODES.KANBAN}>Kanban</TabsTrigger>
-                            <TabsTrigger className="w-[100px]" value={VIEW_MODES.LIST}>List</TabsTrigger>
+                        <TabsList className="px-3 py-6 w-full md:max-w-max">
+                            <TabsTrigger className="w-full md:w-[100px]" value={VIEW_MODES.KANBAN}>Kanban</TabsTrigger>
+                            <TabsTrigger className="w-full md:w-[100px]" value={VIEW_MODES.LIST}>List</TabsTrigger>
                         </TabsList>
                     </header>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,58 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+export default function DashboardPage() {
+    // TODO: workspaces should be populated with users workspaces provided by backend
+    const WORKSPACES = [
+        {
+            value: "wayne_industries",
+            label: "Wayne Industries"
+        },
+        {
+            value: "avengers",
+            label: "Avengers"
+        },
+        {
+            value: "jap_software",
+            label: "JAP Software"
+        },
+    ]
+
+    return (
+        <main className="min-h-screen p-12">
+            <nav className="flex flex-col gap-4">
+                <div className="flex gap-6">
+                    <Select>
+                        <SelectTrigger className="w-1/5">
+                            <SelectValue placeholder="Workspace" />
+                        </SelectTrigger>   
+
+                        <SelectContent>
+                            {WORKSPACES.map(({ value, label }) => (
+                                <SelectItem key={value} value={value}>{label}</SelectItem> 
+                            ))}
+                        </SelectContent>
+                    </Select> 
+
+                    <Input placeholder="Search for a task (Ctrl + K)" />
+
+                    <Avatar className="rounded-md">
+                        {/* TODO: `src` property should reference to user avatar database column */}
+                        <AvatarImage src="https://www.clipartmax.com/png/middle/105-1055054_view-golang-think-logo-golang.png"/>
+
+                        {/* TODO: fallback should be fullfilled with the first letters of the user name and lastname */}
+                        <AvatarFallback>GO</AvatarFallback>
+                    </Avatar>
+                </div>
+
+                <div>
+
+                </div>
+            </nav>
+
+            <section className="h-full">
+            </section>
+        </main>
+    )
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
# What
- Implement navigation section for the dashboard page.
- Install needed **shadcn/ui** components: `Tabs`, `Avatar`.

# How
- Create `dashboard/page.tsx` directory and page.
- Implement coding for rendering workspace selector, search input, avatar and tabs.
- Read `view` query parameter from url and use it as default view mode for tabs

# Screenshots
![image](https://github.com/pedrouzcategui/todopractice/assets/99158056/52190e9f-a25c-494f-a322-d2a1c754bfe1)
